### PR TITLE
Switch use of Pervasives to Stdlib for new ocaml version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ This is a compiler that partitions functions' [LLVM][] intermediate representati
 Installing Dependencies
 ------
 
+The OCaml implementation assumes [Ocaml][] 4.08.1.
+
+    $ brew install ocaml
+
 We recommend installing dependencies via OCaml's [opam][] package manager.
 
 On OSX:
@@ -61,6 +65,7 @@ You can add this LLVM installation and the installed libraries to your path with
     
 (The exact path may differ based on your installation method.)
 
+[ocaml]: https://ocaml.org/
 [opam]: https://opam.ocaml.org
 [binary installation script]: https://opam.ocaml.org/doc/Install.html#Binary-distribution
 [dune]: https://github.com/ocaml/dune

--- a/src/partition.ml
+++ b/src/partition.ml
@@ -1,5 +1,5 @@
 open Smtlib
-open Pervasives
+open Stdlib
 open Llvm
 open Llvm_shared
 

--- a/src/visualize.ml
+++ b/src/visualize.ml
@@ -29,14 +29,14 @@ let edge_attribute ((_, p1, _), _, (_, p2, _)) =
 
 module VNode = struct
   type t = (llvalue * int * (int * int))
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
   let hash = Hashtbl.hash
   let equal = (==)
 end
 
 module VEdge = struct
   type t = string
-  let compare = Pervasives.compare
+  let compare = Stdlib.compare
   let equal = (=)
   let default = ""
 end


### PR DESCRIPTION
Small changes so that the project works with Ocaml 4.08.1. I don't know if you want to use a newer version of OCaml, but I thought I would make this anyways. I had some problems with the ocaml-z3 dependency which require me to build it from source. I don't know if this is a problem with a newer version of opam or ocaml. 