### PR TITLE
[Makefile] Add Target LLVMIR -> LLVM bitcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ test_save:
 %.bc: %.c
 	clang -emit-llvm -Xclang -disable-lifetime-markers  $(TARGET_FLAGS) -O1 -c $< -o $@
 
+%.bc: %.ll
+	clang -emit-llvm -Xclang -disable-lifetime-markers  $(TARGET_FLAGS) -O1 -c $< -o $@
+
 %.png : %.dot
 	dot -Tpng $< > $@
 


### PR DESCRIPTION
- Added a Makefile Target to compile LLVMIR to LLVM bitcode. 

Is there a simple way to write a single recipe for a single target, with a list of "OR" prerequisites in Makefile?