### PR TITLE
[README.md] Opam pin for llvm to make consistent with homebrew version

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ On Linux:
 
 Then:
 
-    $ opam install llvm
+    $ opam pin add llvm 8.0.0
 
 You can add this LLVM installation and the installed libraries to your path with:
 


### PR DESCRIPTION
- opam llvm is now at 10.0.0 as of April 20
- Ran into some issues when opam llvm version was 9.0.0 and Homebrew version was 8.0.0 for Hyacinth
- We can change this once we upgrade to llvm 9.0.0